### PR TITLE
Initial sanger adaptations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,11 @@ ME=$(shell whoami)
 GIT_SUPPORT_PATH=  ${HOME}/.git-support
 HOOKS=${GIT_SUPPORT_PATH}/hooks
 PRECOMMIT=${GIT_SUPPORT_PATH}/hooks/pre-commit
+PREPUSH=${GIT_SUPPORT_PATH}/hooks/pre-push
 PATTERNS=${GIT_SUPPORT_PATH}/gitleaks.toml
 GITLEAKS= /usr/local/bin/gitleaks
 
-INSTALL_TARGETS= ${PATTERNS} ${PRECOMMIT} ${GITLEAKS}
+INSTALL_TARGETS= ${PATTERNS} ${PRECOMMIT} ${PREPUSH} ${GITLEAKS}
 
 .PHONY: clean audit global_hooks
 
@@ -40,8 +41,11 @@ ${PATTERNS}: local.toml ${GIT_SUPPORT_PATH}
 ${PRECOMMIT}: pre-commit.sh ${HOOKS}
 	install -m 0755 -cv $< $@
 
+${PREPUSH}: pre-push.sh ${HOOKS}
+	install -m 0755 -cv $< $@
+
 ${GIT_SUPPORT_PATH} ${HOOKS}:
-	mkdir -p $@ 
+	mkdir -p $@
 
 /usr/local/bin/bats:
 	brew install bats-core

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -14,7 +14,7 @@ gitleaksEnabled=$(git config --bool hooks.gitleaks)
 # but you're actually trying to commit:
 #   database-pass: a-real-damn-password
 # then, you need to see the full output to realize your mistake
-cmd="/usr/local/bin/gitleaks --unstaged --verbose --leaks-exit-code=1 --config-path=$HOME/.git-support/gitleaks.toml"
+cmd="gitleaks --unstaged --verbose --leaks-exit-code=1 --config-path=$HOME/.git-support/gitleaks.toml"
 if [ $gitleaksEnabled == "true" ]; then
     $cmd
     status=$?

--- a/pre-push.sh
+++ b/pre-push.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This calls the pre-push git hook local to the repo
+git_dir=$(git rev-parse --git-dir)
+if [ -f "$git_dir/hooks/pre-push" ]; then
+    set -e
+    "$git_dir/hooks/pre-push" "$@"
+    set +e
+fi


### PR DESCRIPTION
## Changes proposed in this pull request:
- change pre-commit gitleaks run to rely on $PATH rather than hardcoding usr/local/bin, to cope with non-standard homebrew installs
- add support for pre-push local hooks - without this, git wouldn't look in the local repo's .git/hooks folder, as we've changed the core.hooksPath setting to look in the central .git-support location

## security considerations
None - makes installation more flexible and adds pre-push functionality.
